### PR TITLE
Fix right associativity when applying texture scale transform to uv1.

### DIFF
--- a/RGBSubPixelDisplay-Shader/RGBSubPixel.cginc
+++ b/RGBSubPixelDisplay-Shader/RGBSubPixel.cginc
@@ -41,7 +41,8 @@
 
       //do RGB pixels
         //uv1 = round((uv1 *_RGBSubPixelTex_ST.xy) / _RGBSubPixelTex_ST.xy);
-        uv1 *= _RGBSubPixelTex_ST.xy + _RGBSubPixelTex_ST.zw;
+        //*= is right associative so uv1 *= ( S + T ) but we want uv1 * S + T. Thanks StreliaCopy.
+        uv1 = (uv1 * _RGBSubPixelTex_ST.xy) + _RGBSubPixelTex_ST.zw;
         //uv1 *= _RGBSubPixelTex_ST.xy;
         float4 rgbpixel = tex2D(RGBTex, uv1);
 


### PR DESCRIPTION
*= is right associative operator so uv1 *= ( S + T ). 
We just want typical uv1 = (uv1 * S) + T.